### PR TITLE
null and nullcp compression: Add new compression types.

### DIFF
--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -52,6 +52,8 @@ enum zio_compress {
 	ZIO_COMPRESS_ZLE,
 	ZIO_COMPRESS_LZ4,
 	ZIO_COMPRESS_GZIP_NOLOAD,
+	ZIO_COMPRESS_NULLCP,
+	ZIO_COMPRESS_NULL,
 	ZIO_COMPRESS_FUNCTIONS
 };
 
@@ -109,7 +111,14 @@ extern size_t lz4_compress_zfs(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
 extern int lz4_decompress_zfs(void *src, void *dst, size_t s_len, size_t d_len,
     int level);
-
+extern size_t nullcp_compress(void *src, void *dst, size_t s_len, size_t d_len,
+    int level);
+extern int nullcp_decompress(void *src, void *dst, size_t s_len, size_t d_len,
+    int level);
+extern size_t null_compress(void *src, void *dst, size_t s_len, size_t d_len,
+    int level);
+extern int null_decompress(void *src, void *dst, size_t s_len, size_t d_len,
+    int level);
 /*
  * Compress and decompress data if necessary.
  */

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -89,6 +89,7 @@ KERNEL_C = \
 	mmp.c \
 	multilist.c \
 	objlist.c \
+	nullc.c \
 	pathname.c \
 	range_tree.c \
 	refcount.c \

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -120,6 +120,8 @@ zfs_prop_init(void)
 		{ "zle",	ZIO_COMPRESS_ZLE },
 		{ "lz4",	ZIO_COMPRESS_LZ4 },
 		{ "gzip-noload",ZIO_COMPRESS_GZIP_NOLOAD },
+		{ "nullcp",	ZIO_COMPRESS_NULLCP },
+		{ "null",	ZIO_COMPRESS_NULL },
 		{ NULL }
 	};
 
@@ -307,7 +309,7 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_COMPRESSION, "compression",
 	    ZIO_COMPRESS_DEFAULT, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4", "COMPRESS",
+	    "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4 | nullcp | null", "COMPRESS",
 	    compress_table);
 	zprop_register_index(ZFS_PROP_SNAPDIR, "snapdir", ZFS_SNAPDIR_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -64,6 +64,7 @@ $(MODULE)-objs += mmp.o
 $(MODULE)-objs += multilist.o
 $(MODULE)-objs += noload.o
 $(MODULE)-objs += objlist.o
+$(MODULE)-objs += nullc.o
 $(MODULE)-objs += pathname.o
 $(MODULE)-objs += range_tree.o
 $(MODULE)-objs += refcount.o

--- a/module/zfs/nullc.c
+++ b/module/zfs/nullc.c
@@ -1,0 +1,87 @@
+/*
+ * null - a null compression algorithm
+ * Header File
+ * Copyright (C) 2019, Eideticom
+ * BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <sys/zfs_context.h>
+
+/*ARGSUSED*/
+size_t
+nullcp_compress(void *s_start, void *d_start, size_t s_len,
+    size_t d_len, int n)
+{
+
+	/*
+	 * Perform a s_len memcpy from s_start to d_start and return
+	 * s_len. Note, this will cause a compression abort in the
+	 * layer above but that does not matter since the SW path has
+	 * at least been tested.
+	 */
+	memcpy(d_start, s_start, s_len);
+	return (s_len);
+}
+
+/*ARGSUSED*/
+int
+nullcp_decompress(void *s_start, void *d_start, size_t s_len,
+    size_t d_len, int n)
+{
+	/*
+	 * Perform a s_len memcpy from s_start to d_start and return
+	 * s_len.
+	*/
+	memcpy(d_start, s_start, s_len);
+	return (s_len);
+}
+
+/*ARGSUSED*/
+size_t
+null_compress(void *s_start, void *d_start, size_t s_len,
+    size_t d_len, int n)
+{
+
+	/*
+	 * Return s_len. Note, this will cause a compression abort in
+	 * the layer above but that does not matter since the SW path
+	 * has at least been tested.
+	 */
+	return (s_len);
+}
+
+/*ARGSUSED*/
+int
+null_decompress(void *s_start, void *d_start, size_t s_len,
+    size_t d_len, int n)
+{
+	/*
+	 * Return s_len. This probably causes odd things to happen so
+	 * you may prefer to use nullcp.
+	 */
+	return (s_len);
+}

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -69,6 +69,8 @@ zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 #else
 	{"gzip-noload",         0,      NULL,           NULL, NULL},
 #endif
+	{"nullcp",		0,	nullcp_compress, nullcp_decompress},
+	{"null",		0,	null_compress, null_decompress}
 };
 
 enum zio_compress


### PR DESCRIPTION
Add two new null compression types. nullcp simply performs a memcpy()
from the compression input buffer to the compression output
buffer. null skips the memcpy() and simply returns the length of the
input buffer. Note that null could be very bad for reads although a
failure path for non-compressible blocks should save us here. These
two null compression types should be useful for performance testing
the compresssion path without actually taxing the CPU or offload
engine with compression.

Signed-off-by: Stephen Bates <sbates@raithlin.com>
