### PR TITLE
noload: Do not attempt to compress tiny entries

### DIFF
--- a/module/zfs/noload.c
+++ b/module/zfs/noload.c
@@ -28,6 +28,8 @@
 #include <sys/zfs_context.h>
 #include <sys/abd.h>
 
+#define MIN_CMP_SIZE (64 * 1024)
+
 struct nvme_algo;
 
 int nvme_algo_run(struct nvme_algo *alg, struct bio *src,
@@ -158,6 +160,9 @@ size_t noload_compress(abd_t *src, void *dst, size_t s_len, size_t d_len,
 		       int level)
 {
 	ssize_t ret;
+
+	if (s_len < MIN_CMP_SIZE)
+		return s_len;
 
 	ret = __noload_run(noload_c_alg, src, dst, s_len, d_len, level);
 	if (ret < 0)


### PR DESCRIPTION
Testing has shown that many small compression jobs may be sent to
noload_compress, this patch discards jobs < 64kB to prevent wasted
traffic to nvme-algo.  This may be a candidate for sw fallback if we want
tiny entry compression in the future and have a way to separate them on
decompression.
