### PR TITLE
noload: Treat out_len > d_len as error

### DIFF
--- a/module/zfs/noload.c
+++ b/module/zfs/noload.c
@@ -143,7 +143,7 @@ static ssize_t __noload_run(struct nvme_algo *alg, abd_t *src, void *dst,
 	bio_map_buf(bio_dst, dst, d_len);
 
 	ret = nvme_algo_run(alg, bio_src, s_len, bio_dst, &out_len);
-	if (ret) {
+	if (ret || out_len > d_len) {
 		if (ret == -ENODEV) {
 			noload_disable();
 			return -1;


### PR DESCRIPTION
When and algo runs a job it is possible for the number of output bytes
processed to exceed the number of bytes read.  In this case not all of
the data output is accessible to zfs and this should be treated as a
compression/decompression failure.