### PR TITLE
Add SW Gzip Fallback for NoLoad Compression

### DIFF
--- a/include/sys/zio_compress.h
+++ b/include/sys/zio_compress.h
@@ -51,6 +51,7 @@ enum zio_compress {
 	ZIO_COMPRESS_GZIP_9,
 	ZIO_COMPRESS_ZLE,
 	ZIO_COMPRESS_LZ4,
+	ZIO_COMPRESS_GZIP_NOLOAD,
 	ZIO_COMPRESS_FUNCTIONS
 };
 
@@ -119,6 +120,21 @@ extern int zio_decompress_data(enum zio_compress c, abd_t *src, void *dst,
     size_t s_len, size_t d_len);
 extern int zio_decompress_data_buf(enum zio_compress c, void *src, void *dst,
     size_t s_len, size_t d_len);
+
+extern size_t noload_compress(abd_t *src, void *dst, size_t s_len,
+    size_t d_len, int level);
+extern int noload_decompress(abd_t *src, void *dst, size_t s_len,
+    size_t d_len, int level);
+
+#if defined(_KERNEL) && defined(HAVE_NVME_ALGO)
+extern void noload_disable(void);
+extern void noload_request(void);
+extern void noload_release(void);
+#else
+static inline void noload_disable(void) {}
+static inline void noload_request(void) {}
+static inline void noload_release(void) {}
+#endif /* _KERNEL && HAVE_NVME_ALGO */
 
 #ifdef	__cplusplus
 }

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -104,21 +104,22 @@ zfs_prop_init(void)
 	};
 
 	static zprop_index_t compress_table[] = {
-		{ "on",		ZIO_COMPRESS_ON },
-		{ "off",	ZIO_COMPRESS_OFF },
-		{ "lzjb",	ZIO_COMPRESS_LZJB },
-		{ "gzip",	ZIO_COMPRESS_GZIP_6 },	/* gzip default */
-		{ "gzip-1",	ZIO_COMPRESS_GZIP_1 },
-		{ "gzip-2",	ZIO_COMPRESS_GZIP_2 },
-		{ "gzip-3",	ZIO_COMPRESS_GZIP_3 },
-		{ "gzip-4",	ZIO_COMPRESS_GZIP_4 },
-		{ "gzip-5",	ZIO_COMPRESS_GZIP_5 },
-		{ "gzip-6",	ZIO_COMPRESS_GZIP_6 },
-		{ "gzip-7",	ZIO_COMPRESS_GZIP_7 },
-		{ "gzip-8",	ZIO_COMPRESS_GZIP_8 },
-		{ "gzip-9",	ZIO_COMPRESS_GZIP_9 },
-		{ "zle",	ZIO_COMPRESS_ZLE },
-		{ "lz4",	ZIO_COMPRESS_LZ4 },
+		{ "on",		 ZIO_COMPRESS_ON },
+		{ "off",	 ZIO_COMPRESS_OFF },
+		{ "lzjb",	 ZIO_COMPRESS_LZJB },
+		{ "gzip",	 ZIO_COMPRESS_GZIP_6 },	/* gzip default */
+		{ "gzip-1",	 ZIO_COMPRESS_GZIP_1 },
+		{ "gzip-2",	 ZIO_COMPRESS_GZIP_2 },
+		{ "gzip-3",	 ZIO_COMPRESS_GZIP_3 },
+		{ "gzip-4",	 ZIO_COMPRESS_GZIP_4 },
+		{ "gzip-5",	 ZIO_COMPRESS_GZIP_5 },
+		{ "gzip-6",	 ZIO_COMPRESS_GZIP_6 },
+		{ "gzip-7",	 ZIO_COMPRESS_GZIP_7 },
+		{ "gzip-8",	 ZIO_COMPRESS_GZIP_8 },
+		{ "gzip-9",	 ZIO_COMPRESS_GZIP_9 },
+		{ "zle",	 ZIO_COMPRESS_ZLE },
+		{ "lz4",	 ZIO_COMPRESS_LZ4 },
+		{ "gzip-noload", ZIO_COMPRESS_GZIP_NOLOAD },
 		{ NULL }
 	};
 

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -60,6 +60,7 @@ $(MODULE)-objs += lz4.o
 $(MODULE)-objs += metaslab.o
 $(MODULE)-objs += mmp.o
 $(MODULE)-objs += multilist.o
+$(MODULE)-objs += noload.o
 $(MODULE)-objs += pathname.o
 $(MODULE)-objs += policy.o
 $(MODULE)-objs += range_tree.o

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -61,6 +61,7 @@
 #include <sys/spa_impl.h>
 #include <sys/dmu_recv.h>
 #include <sys/zfs_project.h>
+#include <sys/zio_compress.h>
 #include "zfs_namecheck.h"
 
 /*
@@ -192,6 +193,13 @@ compression_changed_cb(void *arg, uint64_t newval)
 	 * Inheritance and range checking should have been done by now.
 	 */
 	ASSERT(newval != ZIO_COMPRESS_INHERIT);
+
+	if (os->os_compress == ZIO_COMPRESS_GZIP_NOLOAD &&
+	    newval != ZIO_COMPRESS_GZIP_NOLOAD)
+		noload_release();
+	else if (os->os_compress != ZIO_COMPRESS_GZIP_NOLOAD &&
+	    newval == ZIO_COMPRESS_GZIP_NOLOAD)
+		noload_request();
 
 	os->os_compress = zio_compress_select(os->os_spa, newval,
 	    ZIO_COMPRESS_ON);

--- a/module/zfs/noload.c
+++ b/module/zfs/noload.c
@@ -1,0 +1,190 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Eidetic Communications Inc.
+ * Use is subject to license terms.
+ */
+
+#if defined(_KERNEL) && defined(HAVE_NVME_ALGO)
+#include <sys/zfs_context.h>
+#include <sys/abd.h>
+
+struct nvme_algo;
+
+int nvme_algo_run(struct nvme_algo *alg, struct bio *src,
+    u64 src_len, struct bio *dst, u64 *dst_len);
+struct nvme_algo *nvme_algo_find(const char *algo_name, const char *dev_name);
+void nvme_algo_put(struct nvme_algo *alg);
+
+static struct nvme_algo *noload_c_alg, *noload_d_alg;
+static atomic_t req_count;
+
+static void
+noload_enable(void)
+{
+	if (noload_c_alg || noload_d_alg)
+		return;
+
+	if (!atomic_read(&req_count))
+		return;
+
+	noload_c_alg = nvme_algo_find("deflate", NULL);
+	noload_d_alg = nvme_algo_find("inflate", NULL);
+	printk(KERN_NOTICE "ZFS: Using Noload Compression\n");
+}
+
+void
+noload_disable(void)
+{
+	printk(KERN_NOTICE "ZFS: Noload Compression Disabled\n");
+	nvme_algo_put(noload_c_alg);
+	nvme_algo_put(noload_d_alg);
+	noload_c_alg = NULL;
+	noload_d_alg = NULL;
+}
+
+void
+noload_request(void)
+{
+	if (atomic_inc_return(&req_count) == 1)
+		noload_enable();
+}
+
+void
+noload_release(void)
+{
+	if (atomic_dec_and_test(&req_count))
+		noload_disable();
+}
+
+static void
+bio_map_buf(struct bio *bio, void *data, unsigned int len)
+{
+	unsigned long kaddr = (unsigned long)data;
+	unsigned long end = (kaddr + len + PAGE_SIZE - 1) >> PAGE_SHIFT;
+	unsigned long start = kaddr >> PAGE_SHIFT;
+
+	const int nr_pages = end - start;
+	bool is_vmalloc = is_vmalloc_addr(data);
+	struct page *page;
+	int offset, i;
+
+	offset = offset_in_page(kaddr);
+	for (i = 0; i < nr_pages; i++) {
+		unsigned int bytes = PAGE_SIZE - offset;
+
+		if (len <= 0)
+			break;
+
+		if (bytes > len)
+			bytes = len;
+
+		if (!is_vmalloc)
+			page = virt_to_page(data);
+		else
+			page = vmalloc_to_page(data);
+
+		bio_add_page(bio, page, bytes, offset);
+
+		data += bytes;
+		len -= bytes;
+		offset = 0;
+	}
+}
+
+static int
+abd_to_bio_cb(void *buf, size_t size, void *priv)
+{
+	struct bio *bio = priv;
+
+	bio_map_buf(bio, buf, size);
+
+	return (0);
+}
+
+static ssize_t
+__noload_run(struct nvme_algo *alg, abd_t *src, void *dst,
+    size_t s_len, size_t d_len, int level)
+{
+	struct bio *bio_src, *bio_dst;
+	u64 out_len = s_len;
+	int ret;
+
+	if (!alg)
+		return (-1);
+
+	bio_src = bio_kmalloc(GFP_KERNEL, s_len / PAGE_SIZE + 1);
+	if (!src)
+		return (-1);
+
+	bio_dst = bio_kmalloc(GFP_KERNEL, d_len / PAGE_SIZE + 1);
+	if (!dst) {
+		bio_put(bio_src);
+		return (-1);
+	}
+
+	bio_src->bi_end_io = bio_put;
+	bio_dst->bi_end_io = bio_put;
+
+	abd_iterate_func(src, 0, s_len, abd_to_bio_cb, bio_src);
+
+	bio_map_buf(bio_dst, dst, d_len);
+
+	ret = nvme_algo_run(alg, bio_src, s_len, bio_dst, &out_len);
+	if (ret) {
+		if (ret == -ENODEV) {
+			noload_disable();
+			return (-1);
+		}
+		out_len = s_len;
+	}
+
+	return (out_len);
+}
+
+size_t
+noload_compress(abd_t *src, void *dst, size_t s_len, size_t d_len,
+    int level)
+{
+	ssize_t ret;
+
+	ret = __noload_run(noload_c_alg, src, dst, s_len, d_len, level);
+	if (ret < 0)
+		return (s_len);
+
+	return (ret);
+}
+
+int
+noload_decompress(abd_t *src, void *dst, size_t s_len, size_t d_len,
+    int level)
+{
+	ssize_t ret;
+
+	ret = __noload_run(noload_d_alg, src, dst, s_len, d_len, level);
+	if (ret < 0)
+		return (-1);
+
+	return (0);
+}
+
+#endif

--- a/module/zfs/noload.c
+++ b/module/zfs/noload.c
@@ -168,8 +168,6 @@ noload_compress(abd_t *src, void *dst, size_t s_len, size_t d_len,
 	ssize_t ret;
 
 	ret = __noload_run(noload_c_alg, src, dst, s_len, d_len, level);
-	if (ret < 0)
-		return (s_len);
 
 	return (ret);
 }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -200,6 +200,7 @@
 #include <sys/zfeature.h>
 #include <sys/zcp.h>
 #include <sys/zio_checksum.h>
+#include <sys/zio_compress.h>
 #include <sys/vdev_removal.h>
 #include <sys/zfs_sysfs.h>
 #include <sys/vdev_impl.h>
@@ -7428,6 +7429,8 @@ out:
 static void __exit
 _fini(void)
 {
+	noload_disable();
+
 	zfs_detach();
 	zfs_sysfs_fini();
 	zfs_fini();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->
I added a fallback to use Gzip compression in case there is no NoLoad nvme-algo deflate available.
<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the event no NoLoad nvme-algo deflate is present, the old code would just fail out a not compress that data at all. This can cause an issue if there is only a nvme-algo inflate. In this case we do want to compress that data still (using gzip), so we can uncompress the data using the NoLoads. The only way this is possible is for the block pointer to be marked as being compressed by gzip-noload. So, as a default we should just compress that data using Gzip and still mark the block pointer with gzip-noload compression. 
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
In zio_compress_data() we first attempt to use the ci_compress_abd function for gzip-noload. However, if -1 is returned, we will just fall back to the gzip compression. This is done by setting ci_compress to be set to gzip_compression with a level of 6.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Just did minor testing. In reality, this repo needs to run the ZTS test suite along with zloop to make sure all changes do not break anything out side of this patch.
<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu Eideticom 5.6.0+ kernel.
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
