### PR TITLE
Adding Falling back to SW Compression for NoLoad

### DIFF
--- a/module/zfs/noload.c
+++ b/module/zfs/noload.c
@@ -31,6 +31,14 @@
 #define MIN_CMP_SIZE (64 * 1024)
 #define ALGO_ALIGN	512
 
+static bool noload_on_fail_dont_compress = true;
+module_param(noload_on_fail_dont_compress, bool, 0644);
+MODULE_PARM_DESC(noload_on_fail_dont_compress,
+		 "when true, don't compress data if the noload fails to "
+		 "compress; when false, use gzip as a fallback when the "
+		 "noload fails which can result in excessive CPU usage in "
+		 "some cases");
+
 struct nvme_algo;
 
 int nvme_algo_run(struct nvme_algo *alg, struct bio *src,
@@ -240,7 +248,7 @@ size_t noload_compress(abd_t *src, void *dst, size_t s_len, size_t d_len,
 		return s_len;
 
 	ret = __noload_run(noload_c_alg, src, dst, s_len, d_len, level);
-	if (ret < 0)
+	if (ret < 0 && noload_on_fail_dont_compress)
 		return s_len;
 
 	return ret;

--- a/module/zfs/zio_compress.c
+++ b/module/zfs/zio_compress.c
@@ -64,7 +64,7 @@ zio_compress_info_t zio_compress_table[ZIO_COMPRESS_FUNCTIONS] = {
 	{"zle",			64,	zle_compress,	zle_decompress},
 	{"lz4",			0,	lz4_compress_zfs, lz4_decompress_zfs},
 #if defined(_KERNEL) && defined(HAVE_NVME_ALGO)
-	{"gzip-noload",         0,      NULL,           gzip_decompress,
+	{"gzip-noload",         6,      gzip_compress,  gzip_decompress,
 			noload_compress, noload_decompress},
 #else
 	{"gzip-noload",         0,      NULL,           NULL, NULL},
@@ -136,6 +136,18 @@ zio_compress_data(enum zio_compress c, abd_t *src, void *dst, size_t s_len)
 	if (ci->ci_compress_abd) {
 		c_len = ci->ci_compress_abd(src, dst, s_len, d_len,
 					    ci->ci_level);
+		if (c_len < 0 && ci->ci_compress) {
+			/*
+			 * Hardware compression failed, fall back to
+			 * software.
+			 */
+			void *tmp = abd_borrow_buf_copy(src, s_len);
+			c_len = ci->ci_compress(tmp, dst, s_len, d_len,
+			    ci->ci_level);
+			abd_return_buf(src, tmp, s_len);
+		} else if (c_len < 0) {
+			c_len = s_len;
+		}
 	} else {
 		/* No compression algorithms can read from ABDs directly */
 		void *tmp = abd_borrow_buf_copy(src, s_len);


### PR DESCRIPTION
This is a slightly cleaned up, rebased and retargeted version of #7 which adds a software fallback if the noload fails to compress.