### PR TITLE
Show gzip-noload as a compression option and add it to the zfs tests

### DIFF
--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -307,8 +307,11 @@ zfs_prop_init(void)
 	zprop_register_index(ZFS_PROP_COMPRESSION, "compression",
 	    ZIO_COMPRESS_DEFAULT, PROP_INHERIT,
 	    ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4", "COMPRESS",
-	    compress_table);
+	    "on | off | lzjb | gzip | gzip-[1-9] | zle | lz4"
+#ifdef HAVE_NVME_ALGO
+	    "| gzip-noload"
+#endif
+	    , "COMPRESS", compress_table);
 	zprop_register_index(ZFS_PROP_SNAPDIR, "snapdir", ZFS_SNAPDIR_HIDDEN,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM,
 	    "hidden | visible", "SNAPDIR", snapdir_table);

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -2531,6 +2531,10 @@ function get_compress_opts
 	if [[ $? -eq 0 ]]; then
 		valid_opts="$valid_opts $GZIP_OPTS"
 	fi
+	zfs get 2>&1 | grep -q gzip-noload
+	if [[ $? -eq 0 ]]; then
+		valid_opts="$valid_opts gzip-noload"
+	fi
 	echo "$valid_opts"
 }
 

--- a/tests/zfs-tests/tests/perf/perf.shlib
+++ b/tests/zfs-tests/tests/perf/perf.shlib
@@ -24,8 +24,14 @@ export PERF_RUNTIME_WEEKLY=$((30 * 60))
 export PERF_RUNTIME_NIGHTLY=$((10 * 60))
 
 # Default fs creation options
-export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=lz4' \
-    ' -o checksum=sha256 -o redundant_metadata=most'}
+if zfs get 2>&1 | grep -q gzip-noload
+then
+	export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=gzip-noload' \
+	    ' -o checksum=sha256 -o redundant_metadata=most'}
+else
+	export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=lz4' \
+	    ' -o checksum=sha256 -o redundant_metadata=most'}
+fi
 
 function get_sync_str
 {


### PR DESCRIPTION
Noload compression wasn't showing as a valid compression option in the zfs get/set commands, so we add it to the list in the first commit.

The second commit adds gzip-noload to zfs' functional tests.

Finally, we add noload compression to zfs' performance tests