### PR TITLE
tests: use 1M recsize for performance testing with the NoLoad

### DIFF
--- a/tests/zfs-tests/tests/perf/perf.shlib
+++ b/tests/zfs-tests/tests/perf/perf.shlib
@@ -26,7 +26,7 @@ export PERF_RUNTIME_NIGHTLY=$((10 * 60))
 # Default fs creation options
 if zfs get 2>&1 | grep -q gzip-noload
 then
-	export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=gzip-noload' \
+	export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=1M -o compress=gzip-noload' \
 	    ' -o checksum=sha256 -o redundant_metadata=most'}
 else
 	export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=lz4' \


### PR DESCRIPTION
A larger recordsize makes compression more efficient with the NoLoad.