### PR TITLE
CI: run checkstyle on Ubuntu 18.04

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   checkstyle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
The `checkstyle` github action runs on "ubuntu-latest", but that currently means either 18.04 or 20.04 (see [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on)).

On the upstream zfs repo, this is currently running on 18.04, but on our fork it runs on 20.04.

The test passes on 18.04, but fails on 20.04. So force it to run on 18.04.

Unfortunately, that still won't get us the nice green checkmark, as one of the other tests will fail (and it fails on upstream too). But at least we know that the style is right.